### PR TITLE
Use default DCAwareRoundRobinPolicy instead of LocalNodeFirstLoadBalancingPolicy

### DIFF
--- a/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/cql/CassandraConnectionFactory.scala
+++ b/spark-cassandra-connector/src/main/scala/com/datastax/spark/connector/cql/CassandraConnectionFactory.scala
@@ -47,8 +47,8 @@ object DefaultConnectionFactory extends CassandraConnectionFactory {
         new MultipleRetryPolicy(conf.queryRetryCount))
       .withReconnectionPolicy(
         new ExponentialReconnectionPolicy(conf.minReconnectionDelayMillis, conf.maxReconnectionDelayMillis))
-      .withLoadBalancingPolicy(
-        new LocalNodeFirstLoadBalancingPolicy(conf.hosts, conf.localDC))
+//       .withLoadBalancingPolicy(
+//         new LocalNodeFirstLoadBalancingPolicy(conf.hosts, conf.localDC))
       .withAuthProvider(conf.authConf.authProvider)
       .withSocketOptions(options)
       .withCompression(conf.compression)


### PR DESCRIPTION
`LocalNodeFirstLoadBalancingPolicy` optimized with Spark but specific use case would like to use `DCAwareRoundRobinPolicy` to route traffic to a primary datacenter.